### PR TITLE
Gitea: Start LFS server

### DIFF
--- a/core/gitea/install.py
+++ b/core/gitea/install.py
@@ -170,6 +170,7 @@ def main():
             ; change DOMAIN and ROOT_URL below to your domain and site
             DOMAIN = localhost
             ROOT_URL = http://localhost
+            LFS_START_SERVER = true
 
             [database]
             DB_TYPE = sqlite3


### PR DESCRIPTION
One of the main features of Gitea is its built-in LFS (large-file-storage) support. This requires enabling the feature in the config in order to use. Gitea disables this by default because it requires `git-lfs` to be installed on the server, and they do not want to encumber people with further requirements just to run Gitea out-of-the-box.

Opalstack already has git-lfs installed, so this feature is available for use.
For comparison, Github always has this enabled. We should, too.