### PR TITLE
Gitea: Fix deprecated admin user create flag

### DIFF
--- a/core/gitea/install.py
+++ b/core/gitea/install.py
@@ -192,7 +192,7 @@ def main():
 
     # create initial user
     pw = gen_password()
-    cmd = f'{appdir}/gitea admin user create --name {appinfo["osuser_name"]} \
+    cmd = f'{appdir}/gitea admin user create --username {appinfo["osuser_name"]} \
             --password {pw} --email {appinfo["osuser_name"]}@localhost --admin'
     createuser = run_command(cmd)
     logging.info(f'created initial gitea user {appinfo["osuser_name"]}')


### PR DESCRIPTION
The `--name` flag is deprecated. The Gitea installer currently produces the following warning:
```
[2023-04-06 21:27:01,463] INFO: Running: /home/me/apps/appname/gitea admin user create --name ...
--name flag is deprecated. Use --username instead.
```
We need to fix this in order to prevent the installer from breaking on a future update.