### PR TITLE
fix: ensure NextJs starts in production mode

### DIFF
--- a/core/nextjs/install.py
+++ b/core/nextjs/install.py
@@ -179,7 +179,7 @@ def main():
                 fi
 
                 cd $PROJECTDIR
-                $PROJECTDIR/node_modules/.bin/next --port {appinfo["port"]} > $LOGDIR/logfile.log 2>&1 & echo $! > $PIDFILE
+                $PROJECTDIR/node_modules/.bin/next start --port {appinfo["port"]} > $LOGDIR/logfile.log 2>&1 & echo $! > $PIDFILE
 
                 echo "Started $APPNAME."
                 ''')


### PR DESCRIPTION
## What does this PR do

This PR makes a simple change to the NextJs `start` script, to ensure the server is started in production mode.

## Reason for the change

> Good to know: Running next without a command is the same as running `next dev`

https://nextjs.org/docs/app/api-reference/next-cli

Dev mode is prone to memory leaks, and slow. This change adds the `start` command so that NextJs runs in production mode. 

**IMPORTANT** Running NextJs in production mode requires a build (`next build`). The process will quit (logging to the `logs` folder) in case no build is available.